### PR TITLE
feat: wildcard in splashdown provider filter. improvements to inspector.

### DIFF
--- a/Assets/Test/Editor/DynamicOptionsExample.cs
+++ b/Assets/Test/Editor/DynamicOptionsExample.cs
@@ -1,13 +1,13 @@
 using UnityEngine;
 
-public static class Example  
+public static class DynamicOptionsExample  
 { 
         [Splashdown.OptionsProvider("MySplashdown")]
-        public static Splashdown.Editor.Options ProvideSplashdownOptions() => new()
+        public static Splashdown.Editor.Options MyExample() => new()
         {
                 line1 = "Hello",
                 line2 = "Handsome",
-                textColor = Color.red
+                textColor = Color.red,
         };
        
         

--- a/Packages/com.ale1.splashdown/CHANGELOG.md
+++ b/Packages/com.ale1.splashdown/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog 
 ## com.ale1.Splashdown
 
+##[1.2.3]
+### Added
+- Wildcard character allowd in splashdown provider attribute filter
+- Improvements to splashdown inspector, showing name of script overriding the options.
 
 ##[1.2.2]
 ### Added
 - Improvements to Splashdown inspector: options overriden by dynamic options will be marked with yellow label
-
 
 ## [1.2.1]
 ### Fixed
@@ -27,7 +30,7 @@
 
 ## [1.0.0]
 ### Changed
-- first preview package in npm
+- first preview package in openUPM
 
 ##[0.9.0]
 ### Added

--- a/Packages/com.ale1.splashdown/Editor/Scripts/Options.cs
+++ b/Packages/com.ale1.splashdown/Editor/Scripts/Options.cs
@@ -19,7 +19,7 @@ namespace Splashdown.Editor
         public static int DefaultFontSize => DefaultFont.fontSize;
 
         [HideInInspector]
-        public string fileName;
+        public string source;
 
         public SerializableColor backgroundColor;
         public SerializableColor textColor;
@@ -106,6 +106,7 @@ namespace Splashdown.Editor
             fontGUID = other.fontGUID ?? fontGUID;
             TargetFontSize = other.TargetFontSize.hasValue ? other.TargetFontSize : TargetFontSize;
             backgroundTextureGuid = other.backgroundTextureGuid ?? backgroundTextureGuid;
+            source = other.source;
         }
         
         public void ApplyDefaultValues()

--- a/Packages/com.ale1.splashdown/Editor/Scripts/SplashdownBuildProcessor.cs
+++ b/Packages/com.ale1.splashdown/Editor/Scripts/SplashdownBuildProcessor.cs
@@ -45,7 +45,7 @@ namespace Splashdown.Editor
                     .Select(x=> x.GetGuid)
                     .FirstOrDefault();
 
-                //we only process the first result as we cant have multiole icons.
+                //we only process the first result as we cant have multiple icons.
                 if (_activeIcon != null)
                 {
                     SplashdownController.SetIcons(_activeIcon);

--- a/Packages/com.ale1.splashdown/Editor/Scripts/SplashdownImporter.cs
+++ b/Packages/com.ale1.splashdown/Editor/Scripts/SplashdownImporter.cs
@@ -121,7 +121,7 @@ namespace Splashdown.Editor
             string filename = System.IO.Path.GetFileNameWithoutExtension(ctx.assetPath);
             this.name = filename;
             //save name of splashdown file in Options
-            options.fileName = filename;
+            options.source = filename;
             // Set the sprite path in the options
             options.assetPath = $"{ctx.assetPath}";
 

--- a/Packages/com.ale1.splashdown/Editor/Scripts/SplashdownStyles.cs
+++ b/Packages/com.ale1.splashdown/Editor/Scripts/SplashdownStyles.cs
@@ -1,0 +1,39 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Splashdown.Editor
+{
+    public static class SplashdownStyles
+    {
+        public static Color DynamicLabelColor = Color.yellow;  
+        
+        private static Color? _defaultLabelColor;
+        public static Color DefaultLabelColor
+            {
+                get
+                {
+                    if (!_defaultLabelColor.HasValue)
+                    {
+                        _defaultLabelColor = EditorStyles.label.normal.textColor;
+                    }
+                    return _defaultLabelColor.Value;
+                }
+            }
+
+        private static GUIStyle _templateLabelStyle;
+        public static GUIStyle TemplateLabelStyle
+        {
+            get
+            {
+                if (_templateLabelStyle == null)
+                {
+                    _templateLabelStyle = new GUIStyle(EditorStyles.label);
+                }
+                return _templateLabelStyle;
+            }
+        }
+
+          
+    }
+}
+

--- a/Packages/com.ale1.splashdown/Editor/Scripts/SplashdownStyles.cs.meta
+++ b/Packages/com.ale1.splashdown/Editor/Scripts/SplashdownStyles.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf68c815ad28d4c84a3b3ad345fd3524
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.ale1.splashdown/Editor/Scripts/SplashdownUtils.cs
+++ b/Packages/com.ale1.splashdown/Editor/Scripts/SplashdownUtils.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using UnityEditor;
 using UnityEngine;
+using System.Text.RegularExpressions;
 using Object = UnityEngine.Object;
 
 // ReSharper disable RedundantUsingDirective
@@ -144,11 +145,15 @@ namespace Splashdown.Editor
                             
                             //Check Name is a match
                             OptionsProviderAttribute attribute = (OptionsProviderAttribute)Attribute.GetCustomAttribute(method, typeof(OptionsProviderAttribute));
-                            if(attribute.Filter != null && attribute.Filter != targetName)
+                            if(!IsNameMatch(attribute.Filter, targetName))
                                 continue;
 
                             // If we get here, the method is valid
                             var dynamicOptions = (Options)method.Invoke(null, null);
+                            
+                            //capture the name of the script where these dynamic options are coming from
+                            dynamicOptions.source = method.DeclaringType!.Name +"."+ method.Name;
+                            
                             return dynamicOptions;
                         }
                     }
@@ -156,6 +161,25 @@ namespace Splashdown.Editor
             }
 
             return null; 
+        }
+        
+        
+        public static bool IsNameMatch(string filter, string targetName)
+        {
+            //when filter is empty, by default we count that as a match.  
+            if (String.IsNullOrEmpty(filter))
+            {
+                return true;
+            }
+        
+            // Handle wildcard (*) matching
+            if (filter.Contains('*'))
+            {
+                string pattern = filter.Replace("*", ".*"); // Convert wildcard to regex
+                return Regex.IsMatch(targetName, "^" + pattern + "$");
+            }
+
+            return filter == targetName;
         }
     }
 }

--- a/Packages/com.ale1.splashdown/Editor/Scripts/SplashdownUtils.cs
+++ b/Packages/com.ale1.splashdown/Editor/Scripts/SplashdownUtils.cs
@@ -21,7 +21,6 @@ namespace Splashdown.Editor
             var value = JsonUtility.ToJson(opts);
             EditorPrefs.SetString(key, value);
         }
-        
 
         public static Options GetOptionsFromGuid(string guid)
         {
@@ -162,8 +161,7 @@ namespace Splashdown.Editor
 
             return null; 
         }
-        
-        
+
         public static bool IsNameMatch(string filter, string targetName)
         {
             //when filter is empty, by default we count that as a match.  

--- a/Packages/com.ale1.splashdown/package.json
+++ b/Packages/com.ale1.splashdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.ale1.splashdown",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "displayName": "Splashdown",
   "description": "A unity open-source custom Splash splash and Icon generator",
   "documentationUrl": "https://github.com/Ale1/Splashdown",
@@ -8,7 +8,8 @@
   "licenseUrl": "LICENCE.MD",
   "keywords": [
     "Utils",
-    "Coldtower"
+    "Logos",
+    "Icons"
   ],
   "author": {
     "name": "Ale1",


### PR DESCRIPTION
Wildcard character in splashdown options provider attribute, allowing e.g:   [SplashdownOptionsProvider(My*Logo)] matching with "MyBlueLogo" and "MyRedLogo". 